### PR TITLE
Fix casing for some file paths

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,7 +31,7 @@ module.exports = {
         background_color: `#663399`,
         theme_color: `#663399`,
         display: `minimal-ui`,
-        icon: `./src/images/GrpLogosmall.png`, // This path is relative to the root of the site.
+        icon: `./src/images/GrpLogoSmall.png`, // This path is relative to the root of the site.
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import "./index.scss"
-import UKaidlogo from "./UKaidlogo.png"
+import UKaidlogo from "./ukaidlogo.png"
 import SWElogo from "./SWElogo.png"
 
 const Footer = () => {

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { Link } from "gatsby"
 import "./index.scss"
-import Logo from "./GrpLogo.png"
+import Logo from "./GRPlogo.png"
 import Socialmedia from "./socialmedia.png"
 
 


### PR DESCRIPTION
When deploying to Netlify, builds are failing with these messages:

```
Error: icon (./src/images/GrpLogosmall.png) does not exist as defined in gatsb  y-config.js. Make sure the file exists relative to the root of the site.
Can't resolve './GrpLogo.png' in '/opt/build/repo/src/components/NavBar'
Can't resolve './UKaidlogo.png' in '/opt/build/repo/src/components/Footer'
```

When building locally (`npm run build`), things are working well. This is most likely because our local filesystems are case-insensitive where as Netlify's build machines are case-sensitive.